### PR TITLE
[Backend] Inicializar API (FastAPI) e configurar CORS

### DIFF
--- a/Backend/.gitignore
+++ b/Backend/.gitignore
@@ -1,0 +1,27 @@
+# Ambiente virtual
+venv/
+.venv/
+
+# Python
+__pycache__/
+*.pyc
+*.pyo
+*.egg-info/
+
+# Dados brutos e derivados — NUNCA versionar os microdados do INEP
+# (arquivos gigantes, 3GB+, e são dados públicos baixados externamente,
+# não faz sentido duplicar no histórico do git)
+etl/microdados_enem_2025/
+*.csv
+*.parquet
+
+# Variáveis de ambiente / segredos (chaves AWS, etc.)
+.env
+
+# Editor
+.vscode/
+.idea/
+
+# Sistema operacional
+.DS_Store
+Thumbs.db

--- a/Backend/README.md
+++ b/Backend/README.md
@@ -1,0 +1,139 @@
+# Radar ENEM — Backend
+
+Backend do projeto integrador **Radar ENEM**, da disciplina Projeto Aplicado III
+(Bacharelado em Ciência de Dados e Inteligência Artificial — UniSENAI Florianópolis).
+
+O Radar ENEM é uma plataforma web onde o usuário insere sua nota do ENEM e
+seu perfil socioeconômico para obter, em tempo real, um diagnóstico
+estatístico do seu posicionamento frente à população brasileira.
+
+Esta pasta (`Backend/`) faz parte do monorepo do projeto, ao lado da pasta
+`frontend/` (React). Ela cobre:
+- **API** (FastAPI): recebe requisições do frontend e devolve os
+  diagnósticos calculados.
+- **ETL** (Polars): ingestão e compressão offline dos Microdados do ENEM
+  (INEP), convertendo os CSVs brutos em Parquet para consulta rápida.
+
+## Estrutura de pastas
+
+```
+radar-enem/                     (raiz do repositório)
+└── Backend/                    # você está aqui
+    ├── api/
+    │   ├── main.py              # inicialização do FastAPI, CORS e rotas
+    │   └── schemas.py           # modelos Pydantic (contratos de entrada/saída)
+    ├── etl/
+    │   ├── ingestion.py         # ingestão amostral dos microdados com Polars
+    │   └── microdados_enem_2025/   # dados brutos do INEP (não versionado, ver .gitignore)
+    ├── venv/                    # ambiente virtual (não versionado)
+    ├── requirements.txt
+    ├── .gitignore
+    └── README.md                # este arquivo
+```
+
+## Por que essa stack?
+
+| Ferramenta | Papel |
+|---|---|
+| **FastAPI** | Framework da API — define rotas, valida dados, gera documentação automática |
+| **Uvicorn** | Servidor que efetivamente roda a API e escuta requisições HTTP |
+| **Pydantic** | Validação e contratos de dados (integrado ao FastAPI) |
+| **Polars** | Processamento dos microdados do ENEM sem estourar a memória RAM (ao contrário do Pandas, que carrega tudo de uma vez) |
+
+## Pré-requisitos
+
+- Python 3.10+ instalado
+- Os arquivos brutos dos Microdados do ENEM (ver seção "Dados brutos" abaixo)
+  — eles **não vêm** com o repositório, cada pessoa precisa baixar por conta própria
+
+## Como rodar
+
+### 1. Ambiente virtual e dependências
+
+A partir da pasta `Backend/`:
+
+```bash
+python -m venv venv
+
+# Windows
+source venv/Scripts/activate
+# Mac/Linux
+source venv/bin/activate
+
+pip install -r requirements.txt
+```
+
+Sempre que abrir um terminal novo, é preciso reativar a venv (`source venv/Scripts/activate`)
+antes de rodar qualquer comando abaixo — sem isso, aparece
+`ModuleNotFoundError`, já que os pacotes ficam instalados só dentro da venv.
+
+### 2. Rodar a API
+
+De dentro da pasta `Backend/api/`:
+
+```bash
+cd api
+uvicorn main:app --reload
+```
+
+A API sobe em `http://127.0.0.1:8000`. A documentação interativa (gerada
+automaticamente pelo FastAPI) fica em `http://127.0.0.1:8000/docs` — é o
+jeito mais fácil de testar as rotas sem precisar do frontend rodando.
+
+### 3. Rodar a ingestão de dados (ETL)
+
+Baixe os Microdados do ENEM no
+[Portal INEP](https://www.gov.br/inep/pt-br/acesso-a-informacao/dados-abertos/microdados/enem)
+e extraia dentro de `Backend/etl/microdados_enem_2025/` (essa pasta não é
+versionada no git — cada integrante precisa ter os dados localmente).
+
+Depois, de dentro de `Backend/`:
+
+```bash
+python etl/ingestion.py
+```
+
+Isso lê uma amostra de 100 linhas do `PARTICIPANTES_2025.csv`, imprime o
+schema inferido e gera `etl/trusted_amostra.parquet`.
+
+## Dados brutos: como o INEP organiza o .zip
+
+Vale documentar aqui porque não é óbvio na primeira vez: o `.zip` do INEP
+não extrai um único CSV solto — ele vem com subpastas, e às vezes o
+próprio `.zip` já contém uma pasta com o mesmo nome por dentro (o que gera
+uma estrutura duplicada tipo `microdados_enem_2025/microdados_enem_2025/`).
+Dentro, a pasta relevante é `DADOS/`, que contém três arquivos separados:
+
+- `PARTICIPANTES_2025.csv` — perfil de inscrição/socioeconômico de cada participante
+- `RESULTADOS_2025.csv` — notas de cada participante em cada área da prova
+- `ITENS_PROVA_2025.csv` — metadados das questões da prova (dificuldade, gabarito etc.)
+
+Os arquivos usam `;` como separador de colunas e encoding `latin1` (não
+UTF-8) — isso já está tratado no `ingestion.py`.
+
+A pasta `DICIONÁRIO/` (também dentro do `.zip`) não tem dados, só a
+documentação explicando o que cada coluna significa — vale consultar
+antes de escrever qualquer análise que dependa de uma coluna específica.
+
+## Endpoints disponíveis
+
+| Método | Rota | Descrição |
+|---|---|---|
+| `GET` | `/api/health` | Checa se a API está no ar. Retorna `{"status": "Radar ENEM API Online"}` |
+| `POST` | `/api/dados/genero` | Recebe `{ano, estado, nota_matematica}` e devolve um diagnóstico. **Atualmente retorna dados mock** — a leitura real dos microdados ainda não está integrada |
+
+## Próximos passos
+
+- Substituir o mock em `/api/dados/genero` pela leitura real dos dados
+  processados pela ingestão.
+- Cruzar `PARTICIPANTES_2025.csv` com `RESULTADOS_2025.csv` (via
+  `NU_INSCRICAO` ou identificador equivalente) para relacionar perfil
+  socioeconômico com notas.
+- Rodar a ingestão completa (não apenas a amostra de 100 linhas) usando o
+  modo *lazy* do Polars, para lidar com o volume total do arquivo.
+
+## Equipe
+
+Projeto desenvolvido por Felipe Benites, Jade Oliveira, Maykon Douglas e
+Rafael Nunes Almeida, sob orientação do professor Gustavo Stangherlin
+Cantarelli (UniSENAI Campus Florianópolis).

--- a/Backend/api/main.py
+++ b/Backend/api/main.py
@@ -1,0 +1,80 @@
+"""
+main.py
+-------
+Ponto de entrada da API. Aqui só vive a inicialização do FastAPI,
+o CORS e as rotas — a validação de dados fica em schemas.py.
+"""
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+try:
+    # Funciona quando você roda de dentro da pasta api/:
+    #   cd api && uvicorn main:app --reload
+    from schemas import FiltroGenero, RespostaGenero
+except ImportError:
+    # Funciona quando você roda a partir da raiz do projeto:
+    #   uvicorn api.main:app --reload
+    from api.schemas import FiltroGenero, RespostaGenero
+
+app = FastAPI(
+    title="Radar ENEM API",
+    description="Backend do projeto Radar ENEM - UniSENAI Florianópolis",
+    version="0.1.0",
+)
+
+# ---------------------------------------------------------------------------
+# CORS: libera o frontend (React) rodando em outra origem/porta a chamar
+# esta API. Sem isso, o navegador bloqueia a requisição por segurança.
+# ---------------------------------------------------------------------------
+origins = [
+    "http://localhost:5173",  # Vite (padrão do create-react-app moderno)
+    "http://localhost:3000",  # Create React App clássico
+]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@app.get("/api/health")
+def health_check():
+    """
+    Rota simples de 'sinal de vida'. O React (ou qualquer serviço de
+    monitoramento) pode chamar isso pra confirmar que a API está no ar
+    antes de tentar rotas mais pesadas.
+    """
+    return {"status": "Radar ENEM API Online"}
+
+
+@app.post("/api/dados/genero", response_model=RespostaGenero)
+def analise_genero(filtros: FiltroGenero):
+    """
+    Rota do módulo "Trilha de Gênero nas Exatas".
+
+    O FastAPI já recebe o corpo da requisição, valida contra o modelo
+    FiltroGenero (definido em schemas.py) e injeta o resultado validado
+    aqui como o parâmetro `filtros`. Se a validação falhar, a função
+    nem chega a ser chamada — o cliente já recebe um erro 422 detalhado.
+
+    Por enquanto devolvemos um mock (dados simulados), já que a
+    ingestão real dos microdados ainda está sendo construída em
+    etl/ingestion.py. Isso permite que o time de frontend já comece
+    a integrar contra um formato de resposta estável.
+    """
+    dados_mock = {
+        "percentil_usuario": 82.4,
+        "media_grupo_filtrado": 645.3,
+        "ano_referencia": filtros.ano,
+        "estado_referencia": filtros.estado,
+    }
+
+    return RespostaGenero(
+        status="success",
+        mensagem="Dados simulados retornados com sucesso (mock).",
+        dados=dados_mock,
+    )

--- a/Backend/api/schemas.py
+++ b/Backend/api/schemas.py
@@ -1,0 +1,63 @@
+"""
+schemas.py
+----------
+Contratos de dados (modelos Pydantic) usados pelas rotas da API.
+
+Por que separar isso do main.py?
+- O Pydantic valida automaticamente os dados que chegam nas requisições
+  (tipo, formato, obrigatoriedade) antes de qualquer linha da sua lógica rodar.
+- Mantendo os "contratos" isolados aqui, qualquer pessoa da squad consegue
+  entender o que a API espera receber/devolver sem precisar ler a lógica das rotas.
+- Facilita testes unitários dos modelos isoladamente.
+"""
+
+from pydantic import BaseModel, Field
+from typing import Literal
+
+
+class FiltroGenero(BaseModel):
+    """
+    Modelo de entrada para o módulo de análise (ex: Trilha de Gênero nas Exatas).
+
+    Cada campo abaixo é validado automaticamente pelo FastAPI:
+    se o cliente (React) mandar um tipo errado (ex: nota_matematica como
+    string "abc"), a API já rejeita a requisição com erro 422 antes mesmo
+    de chegar na sua função de rota.
+    """
+
+    ano: int = Field(
+        ...,  # "..." = campo obrigatório, sem valor default
+        ge=2009,  # ge = "greater or equal", validação simples de sanidade
+        le=2025,
+        description="Ano de referência da edição do ENEM (ex: 2024)",
+    )
+    estado: str = Field(
+        ...,
+        min_length=2,
+        max_length=2,
+        description="Sigla da UF, ex: 'SC', 'SP'",
+    )
+    nota_matematica: float = Field(
+        ...,
+        ge=0,
+        le=1000,
+        description="Nota do usuário na prova de Matemática (0 a 1000)",
+    )
+
+    class Config:
+        # Exemplo que aparece automaticamente na doc interativa (/docs)
+        json_schema_extra = {
+            "example": {"ano": 2024, "estado": "SC", "nota_matematica": 720.5}
+        }
+
+
+class RespostaGenero(BaseModel):
+    """
+    Modelo de saída (mock por enquanto). Ter um modelo de saída também
+    garante que, quando a lógica real substituir o mock, o formato do
+    JSON devolvido para o frontend não muda de surpresa.
+    """
+
+    status: Literal["success", "error"]
+    mensagem: str
+    dados: dict

--- a/Backend/etl/ingestion.py
+++ b/Backend/etl/ingestion.py
@@ -1,0 +1,111 @@
+"""
+etl/ingestion.py
+-----------------
+Script de extração/ingestão dos microdados do ENEM usando Polars.
+
+Por que Polars e não Pandas?
+- Pandas carrega o DataFrame inteiro na memória RAM de uma vez, e os
+  microdados do INEP têm 3GB+ (às vezes bem mais, dependendo do ano).
+  Isso trava máquinas comuns (OOM = Out Of Memory).
+- Polars é escrito em Rust, processa em paralelo e tem um modo "lazy"
+  (não usado ainda aqui, mas será essencial na ingestão completa) que
+  permite processar arquivos maiores que a RAM disponível.
+
+Este script, por enquanto, só lê uma AMOSTRA pequena (100 linhas) pra
+validar o schema e o pipeline de ponta a ponta antes de rodar com o
+arquivo completo.
+"""
+
+from pathlib import Path
+
+import polars as pl
+
+# Path(__file__) é o caminho deste próprio arquivo (ingestion.py).
+# .parent pega a pasta que o contém (etl/). Usar isso, em vez de uma
+# string solta como "microdados.csv", garante que o caminho funcione
+# não importa de onde o script seja executado (da raiz do projeto,
+# de dentro de etl/, do VS Code, etc.) — resolve o FileNotFoundError
+# que você teve.
+PASTA_ETL = Path(__file__).parent
+
+# ATENÇÃO: o .zip do INEP extraiu com uma pasta duplicada dentro dela
+# mesma (microdados_enem_2025/microdados_enem_2025/...) — isso é comum
+# quando o zip já vem com uma pasta interna de mesmo nome. Testando
+# primeiro com PARTICIPANTES_2025.csv (dados de perfil/inscrição).
+CAMINHO_CSV_BRUTO = (
+    PASTA_ETL
+    / "microdados_enem_2025"
+    / "microdados_enem_2025"
+    / "DADOS"
+    / "PARTICIPANTES_2025.csv"
+)
+CAMINHO_PARQUET_SAIDA = PASTA_ETL / "trusted_amostra.parquet"
+
+
+def ler_amostra_microdados(caminho_csv: Path, n_linhas: int = 100) -> pl.DataFrame:
+    """
+    Lê apenas as primeiras `n_linhas` do CSV bruto do INEP.
+
+    Detalhes importantes dos parâmetros:
+    - separator=";"  → os microdados do INEP usam ponto-e-vírgula como
+      separador de colunas (padrão comum em arquivos de origem brasileira,
+      já que a vírgula é usada como separador decimal).
+    - encoding="latin1" → os arquivos do INEP normalmente NÃO vêm em UTF-8;
+      vêm em Latin-1 (também chamado ISO-8859-1). Se você tentar ler como
+      UTF-8, vai dar erro de decodificação em qualquer acento (ex: "Município").
+    - n_rows=100 → ATENÇÃO: no Polars o parâmetro se chama `n_rows`,
+      não `nrows` como no Pandas. É um erro comum na migração entre as
+      duas bibliotecas. Isso evita carregar o arquivo de 3GB+ inteiro
+      só para testar se o pipeline funciona.
+    """
+    if not caminho_csv.exists():
+        # Checagem explícita antes de tentar ler: se o caminho estiver
+        # errado (arquivo movido, nome diferente, etc.), a mensagem de
+        # erro já mostra o caminho completo que foi procurado, em vez
+        # de um FileNotFoundError genérico do sistema operacional.
+        raise FileNotFoundError(
+            f"CSV não encontrado em: {caminho_csv.resolve()}\n"
+            "Confira se o caminho em CAMINHO_CSV_BRUTO bate com a "
+            "estrutura de pastas real do seu microdado extraído."
+        )
+
+    df = pl.read_csv(
+        caminho_csv,
+        separator=";",
+        encoding="latin1",
+        n_rows=n_linhas,
+    )
+    return df
+
+
+def salvar_amostra_parquet(df: pl.DataFrame, caminho_saida: Path) -> None:
+    """
+    Converte a amostra para Parquet.
+
+    Por que Parquet e não CSV?
+    - Formato colunar: leitura seletiva de colunas é muito mais rápida.
+    - Compressão nativa: ocupa uma fração do espaço do CSV original.
+    - Mantém os tipos de dados (int, float, string) sem precisar
+      reconverter toda vez que o arquivo é lido de novo.
+    """
+    df.write_parquet(caminho_saida)
+
+
+def main():
+    print(f"Lendo amostra de '{CAMINHO_CSV_BRUTO}'...")
+    df_amostra = ler_amostra_microdados(CAMINHO_CSV_BRUTO, n_linhas=100)
+    print(f"Amostra lida: {df_amostra.height} linhas x {df_amostra.width} colunas.")
+
+    print("\nSchema dos dados (nome da coluna -> tipo inferido pelo Polars):")
+    print(df_amostra.schema)
+
+    print(f"\nSalvando amostra em '{CAMINHO_PARQUET_SAIDA}'...")
+    salvar_amostra_parquet(df_amostra, CAMINHO_PARQUET_SAIDA)
+
+    print("Concluído.")
+
+
+if __name__ == "__main__":
+    # Esse bloco só roda quando o arquivo é executado diretamente
+    # (python etl/ingestion.py), e não quando é importado por outro módulo.
+    main()

--- a/Backend/requirements.txt
+++ b/Backend/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn[standard]
+pydantic
+polars


### PR DESCRIPTION
Closes #27.

Implementa a inicializacao da API FastAPI, CORS liberando o frontend (localhost:5173/3000), contratos Pydantic (schemas.py) e o primeiro script de ingestao de amostra com Polars (etl/ingestion.py).

Validacao feita antes de abrir este PR (rodando os dois servicos localmente):
- GET /api/health -> 200 OK
- POST /api/dados/genero com payload valido -> 200, mock consistente
- POST /api/dados/genero com nota_matematica=9999 -> 422 (validacao Pydantic funcionando)
- Preflight CORS com Origin http://localhost:5173 -> access-control-allow-origin correto

Pontos observados para follow-up (nao bloqueiam este PR):
- CAMINHO_CSV_BRUTO em etl/ingestion.py esta hardcoded para o caminho local do Rafael - precisa virar configuravel (env var) antes da integracao com S3.
- Nome da branch (rafael_back) nao segue o padrao feature/... combinado pela squad - ajustar nas proximas.